### PR TITLE
Special handling of download url for version 0.7.0 and 0.7.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,10 +39,17 @@ class packer(
       } else {
         $arch = '386'
       }
-
+      
+      if versioncmp($version, '0.7.0') >= 0 {
+        $prefix = 'packer_'
+      } else {
+        $prefix = ''
+      }
+      
       $packer_basename = inline_template(
-        "<%= \"#{@version}_#{scope['::kernel'].downcase}_#{@arch}.zip\" %>"
+        "<%= \"#{@prefix}#{@version}_#{scope['::kernel'].downcase}_#{@arch}.zip\" %>"
       )
+      
       $packer_zip = "${cache_dir}/${packer_basename}"
       $packer_url = "${base_url}${packer_basename}"
 


### PR DESCRIPTION
This pull request addresses issue #1.  I only handled 0.7.0 and 0.7.1 as I don't know how future versions of packer will publish artifacts.
