### PR TITLE
Update download URL for Packer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,14 +19,14 @@
 #
 # [*base_url*]
 #  The base download URL to retrieve Packer from, including a
-#  a trailing '/'.  Defaults to: 'https://dl.bintray.com/mitchellh/packer/'.
+#  a trailing '/'.  Defaults to: 'https://releases.hashicorp.com/packer/'.
 #
 class packer(
   $ensure    = 'installed',
   $version   = '0.8.5',
   $bin_dir   = '/usr/local/bin',
   $cache_dir = '/usr/local/packer',
-  $base_url  = 'https://dl.bintray.com/mitchellh/packer/',
+  $base_url  = 'https://releases.hashicorp.com/packer/',
 ){
   validate_re($version, '^\d+\.\d+\.\d+$')
   validate_absolute_path([$bin_dir, $cache_dir])
@@ -65,7 +65,7 @@ class packer(
       )
 
       $packer_zip = "${cache_dir}/${packer_basename}"
-      $packer_url = "${base_url}${packer_basename}"
+      $packer_url = "${base_url}${version}/${packer_basename}"
 
       # Ensure cache directory for Packer's zip archives exists.
       file { $cache_dir:


### PR DESCRIPTION
Use https://releases.hashicorp.com/packer/ as the base URL instead of https://releases.hashicorp.com/packer/.